### PR TITLE
Create a viewing party

### DIFF
--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::ViewingPartiesController < ApplicationController
+  before_action: authenticate_api_key
+
+  def create
+
+  end
+
+  private
+
+  def authenticate_api_key
+    render json: { error: 'Invalid API key' }, status: :unauthorized unless params[:api_key].present?
+  end
+end

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -2,6 +2,11 @@ class Api::V1::ViewingPartiesController < ApplicationController
   before_action: authenticate_api_key
 
   def create
+    host = User.find_by(api_key: params[:api_key])
+    if host.nil?
+      render json: { error: "Host w/ API key required" }, status: unauthorized
+    end
+
     
   end
 

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -1,13 +1,29 @@
 class Api::V1::ViewingPartiesController < ApplicationController
-  before_action: authenticate_api_key
+  before_action :authenticate_api_key
 
   def create
     host = User.find_by(api_key: params[:api_key])
-    if host.nil?
-      render json: { error: "Host w/ API key required" }, status: unauthorized
+    unless host
+      return render json: { error: "Host w/ API key required" }, status: :unauthorized
     end
 
-    
+    viewing_party = ViewingParty.create!(
+      name: params[:name],
+      start_time: params[:start_time],
+      end_time: params[:end_time],
+      movie_id: params[:movie_id],
+      movie_title: params[:movie_title],
+      host: host
+    )
+
+    invitee_ids = params[:invitees].map { |invitee| invitee[:id] }
+    invitees = User.where(id: invitee_ids)
+    # binding.pry
+    invitees.each do |invitee|
+      ViewingPartyUser.create!(viewing_party: viewing_party, user: invitee)
+    end
+
+    render json: ViewingPartySerializer.new(viewing_party), status: :created
   end
 
   private

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::ViewingPartiesController < ApplicationController
   before_action: authenticate_api_key
 
   def create
-
+    
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,11 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :username, presence: true, uniqueness: true
   validates :password, presence: { require: true }
+
   has_secure_password
   has_secure_token :api_key
 
+  has_many :viewing_party_users, dependent: :destroy
+  has_many :hosted_viewing_parties, class_name: 'ViewingParty', foreign_key: :host_id, dependent: :destroy
+  has_many :invited_viewing_parties, through: :viewing_party_users, source: :viewing_party
 end

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -1,7 +1,7 @@
 class ViewingParty < ApplicationRecord
   validates :name, :start_time, :end_time, :movie_id, :movie_title, presence: true
 
-  belongs_to :host, class_name: 'User'
+  belongs_to :host, class_name: 'User', foreign_key: :host_id
   has_many :viewing_party_users, dependent: :destroy
   has_many :invitees, through: :viewing_party_users, source: :user
 end

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -1,0 +1,7 @@
+class ViewingParty < ApplicationRecord
+  validates :name, :start_time, :end_time, :movie_id, :movie_title, presence: true
+
+  belongs_to :host, class_name: 'User'
+  has_many :viewing_party_users, dependent: :destroy
+  has_many :invitees, through: :viewing_party_users, source: :user
+end

--- a/app/models/viewing_party_user.rb
+++ b/app/models/viewing_party_user.rb
@@ -1,0 +1,4 @@
+class ViewingPartyUser < ApplicationRecord
+  belongs_to :viewing_party
+  belongs_to :user
+end

--- a/app/serializers/viewing_party_serializer.rb
+++ b/app/serializers/viewing_party_serializer.rb
@@ -1,7 +1,7 @@
 class ViewingPartySerializer
   include JSONAPI::Serializer
 
-  attributes :name, :start_time, :end_time, :movie_id, movie_title
+  attributes :name, :start_time, :end_time, :movie_id, :movie_title
 
   attribute :invitees do |viewing_party|
     viewing_party.invitees.map do |invitee|

--- a/app/serializers/viewing_party_serializer.rb
+++ b/app/serializers/viewing_party_serializer.rb
@@ -1,0 +1,15 @@
+class ViewingPartySerializer
+  include JSONAPI::Serializer
+
+  attributes :name, :start_time, :end_time, :movie_id, movie_title
+
+  attribute :invitees do |viewing_party|
+    viewing_party.invitees.map do |invitee|
+      {
+        id: invitee.id,
+        name: invitee.name,
+        username: invitee.username
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
       resources :users, only: [:create, :index]
       resources :sessions, only: :create
       resources :movies, only: [:index, :show]
+      resources :viewing_parties, only: :create
+
     end
   end
 end

--- a/db/migrate/20241012220501_create_viewing_parties.rb
+++ b/db/migrate/20241012220501_create_viewing_parties.rb
@@ -1,0 +1,13 @@
+class CreateViewingParties < ActiveRecord::Migration[7.1]
+  def change
+    create_table :viewing_parties do |t|
+      t.string :name
+      t.datetime :start_time
+      t.datetime :end_time
+      t.integer :movie_id
+      t.string :movie_title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241012220801_create_viewing_party_users.rb
+++ b/db/migrate/20241012220801_create_viewing_party_users.rb
@@ -1,0 +1,10 @@
+class CreateViewingPartyUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :viewing_party_users do |t|
+      t.references :viewing_party, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241012221708_add_host_to_viewing_parties.rb
+++ b/db/migrate/20241012221708_add_host_to_viewing_parties.rb
@@ -1,0 +1,5 @@
+class AddHostToViewingParties < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :viewing_parties, :host, null: false, foreign_key: { to_table: :users}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_12_220801) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_12_221708) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_12_220801) do
     t.string "movie_title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "host_id", null: false
+    t.index ["host_id"], name: "index_viewing_parties_on_host_id"
   end
 
   create_table "viewing_party_users", force: :cascade do |t|
@@ -43,6 +45,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_12_220801) do
     t.index ["viewing_party_id"], name: "index_viewing_party_users_on_viewing_party_id"
   end
 
+  add_foreign_key "viewing_parties", "users", column: "host_id"
   add_foreign_key "viewing_party_users", "users"
   add_foreign_key "viewing_party_users", "viewing_parties"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_23_211921) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_12_220801) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,4 +24,25 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_211921) do
     t.index ["api_key"], name: "index_users_on_api_key", unique: true
   end
 
+  create_table "viewing_parties", force: :cascade do |t|
+    t.string "name"
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.integer "movie_id"
+    t.string "movie_title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "viewing_party_users", force: :cascade do |t|
+    t.bigint "viewing_party_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_viewing_party_users_on_user_id"
+    t.index ["viewing_party_id"], name: "index_viewing_party_users_on_viewing_party_id"
+  end
+
+  add_foreign_key "viewing_party_users", "users"
+  add_foreign_key "viewing_party_users", "viewing_parties"
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,4 +9,10 @@ RSpec.describe User, type: :model do
     it { should have_secure_password }
     it { should have_secure_token(:api_key) }
   end
+
+  describe "associations" do
+    it { should have_many(:viewing_party_users) }
+    it { should have_many(:hosted_viewing_parties) }
+    it { should have_many(:invited_viewing_parties) }
+  end
 end

--- a/spec/models/viewing_party_spec.rb
+++ b/spec/models/viewing_party_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe ViewingParty, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:end_time) }
+    it { should validate_presence_of(:start_time) }
+    it { should validate_presence_of(:movie_id) }
+    it { should validate_presence_of(:movie_title) }
+  end
+
+  describe "associations" do
+    it { should have_many(:viewing_party_users) }
+    it { should belong_to(:host) }
+    it { should have_many(:invitees) }
+  end
+end

--- a/spec/models/viewing_party_user_spec.rb
+++ b/spec/models/viewing_party_user_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe ViewingPartyUser, type: :model do
+  describe "associations" do
+    it { should belong_to(:viewing_party) }
+    it { should belong_to(:user) }
+  end
+end
+

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Viewing Parties Requests", type: :request do
+  describe "happy paths" do
+
+  end
+end

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -1,7 +1,66 @@
 require "rails_helper"
 
 RSpec.describe "Viewing Parties Requests", type: :request do
-  describe "happy paths" do
-
+  before(:each) do
+    @host = User.create!(:name => "Stef", :username => "steffy", :password => "231", api_key: Rails.application.credentials.dig(:tmdb, :key))
+    @invitee1 = User.create!(:name => "Tom", :username => "tom_tom", :password => "123")
+    @invitee2 = User.create!(:name => "Jen", :username => "jen_jen", :password => "321")
   end
+
+  describe "happy paths" do
+    it "#create can create a viewing party with a host and invitees and return proper formatted response" do
+      viewing_party_request = {
+        name: "Test Party",
+        start_time: "2025-02-01 10:00:00",
+        end_time: "2025-02-01 14:30:00",
+        movie_id: 278,
+        movie_title: "The Shawshank Redemption",
+        api_key: @host.api_key,
+        invitees: [{id: @invitee1.id, name: @invitee1.name, username: @invitee1.username},
+                  {id: @invitee2.id, name: @invitee2.name, username: @invitee2.username}]
+      }
+
+      post "/api/v1/viewing_parties", params: viewing_party_request
+
+      expect(response).to be_successful
+      json = JSON.parse(response.body, symbolize_names: true)
+      party = json[:data]
+
+      expect(party).to have_key(:id)
+      expect(party).to have_key(:type)
+      expect(party[:type]).to eq("viewing_party")
+      expect(party).to have_key(:attributes)
+      expect(party[:attributes][:name]).to eq("Test Party")
+      expect(party[:attributes][:start_time]).to eq("2025-02-01T10:00:00.000Z")
+      expect(party[:attributes][:end_time]).to eq("2025-02-01T14:30:00.000Z")
+      expect(party[:attributes][:movie_id]).to eq(278)
+      expect(party[:attributes][:movie_title]).to eq("The Shawshank Redemption")
+      expect(party[:attributes][:invitees]).to eq([
+        {id: @invitee1.id, name: @invitee1.name, username: @invitee1.username},
+        {id: @invitee2.id, name: @invitee2.name, username: @invitee2.username}
+      ])
+    end
+  end
+
+  # describe "sad paths" do
+  #   it "#create will render error if there is no host" do
+
+  #   end
+
+  #   it "#create will render error if api key is invalid" do
+
+  #   end
+
+  #   it "#create will render error if party duration is less than movie runtime" do
+
+  #   end
+
+  #   it "#create will render error if end time is before start time" do
+
+  #   end
+
+  #   it "#create will only render correct user ids if some user ids are invalid" do
+
+  #   end
+  # end
 end

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -2,13 +2,34 @@ require "rails_helper"
 
 RSpec.describe "Viewing Parties Requests", type: :request do
   before(:each) do
-    @host = User.create!(:name => "Stef", :username => "steffy", :password => "231", api_key: Rails.application.credentials.dig(:tmdb, :key))
     @invitee1 = User.create!(:name => "Tom", :username => "tom_tom", :password => "123")
     @invitee2 = User.create!(:name => "Jen", :username => "jen_jen", :password => "321")
+    @movie_data = {
+      data: {
+        id: 278,
+        type: "movie",
+        attributes: {
+          title: "The Shawshank Redemption",
+          release_year: 1994,
+          vote_average: 9.3,
+          runtime: 142,
+          genres: ["Drama", "Crime"],
+          summary: "Two imprisoned men bond over...",
+          cast: [],
+          total_reviews: 1000,
+          reviews: []
+        }
+      }
+    }
   end
 
   describe "happy paths" do
     it "#create can create a viewing party with a host and invitees and return proper formatted response" do
+      @host = User.create!(:name => "Stef", :username => "steffy", :password => "231", api_key: Rails.application.credentials.dig(:tmdb, :key))
+      @movie_data
+
+      allow(MovieGateway).to receive(:show_movie_details).with(278).and_return(@movie_data)
+
       viewing_party_request = {
         name: "Test Party",
         start_time: "2025-02-01 10:00:00",
@@ -42,25 +63,120 @@ RSpec.describe "Viewing Parties Requests", type: :request do
     end
   end
 
-  # describe "sad paths" do
-  #   it "#create will render error if there is no host" do
+  describe "sad paths" do
+    it "#create will render error if there is no api key" do
+      viewing_party_request = {
+        name: "Test Party",
+        start_time: "2025-02-01 10:00:00",
+        end_time: "2025-02-01 14:30:00",
+        movie_id: 278,
+        movie_title: "The Shawshank Redemption",
+        api_key: "",
+        invitees: [{id: @invitee1.id, name: @invitee1.name, username: @invitee1.username},
+                  {id: @invitee2.id, name: @invitee2.name, username: @invitee2.username}]
+      }
 
-  #   end
+      post "/api/v1/viewing_parties", params: viewing_party_request
 
-  #   it "#create will render error if api key is invalid" do
+      expect(response).to have_http_status(:unauthorized)
+      unauth_response = JSON.parse(response.body, symbolize_names: true)
+      expect(unauth_response[:error]).to eq("No API key means no movie party!")
+    end
 
-  #   end
+    it "#create will render error if api key is invalid" do
+      viewing_party_request = {
+        name: "Test Party",
+        start_time: "2025-02-01 10:00:00",
+        end_time: "2025-02-01 14:30:00",
+        movie_id: 278,
+        movie_title: "The Shawshank Redemption",
+        api_key: "wrooooooong",
+        invitees: [{id: @invitee1.id, name: @invitee1.name, username: @invitee1.username},
+                  {id: @invitee2.id, name: @invitee2.name, username: @invitee2.username}]
+      }
 
-  #   it "#create will render error if party duration is less than movie runtime" do
+      post "/api/v1/viewing_parties", params: viewing_party_request
 
-  #   end
+      expect(response).to have_http_status(:unauthorized)
+      unauth_response = JSON.parse(response.body, symbolize_names: true)
+      expect(unauth_response[:error]).to eq("Invalid API key")
+    end
 
-  #   it "#create will render error if end time is before start time" do
+    it "#create will render error if party duration is less than movie runtime" do
+      @host = User.create!(:name => "Stef", :username => "steffy", :password => "231", api_key: Rails.application.credentials.dig(:tmdb, :key))
+      @movie_data
+      
+      allow(MovieGateway).to receive(:show_movie_details).with(278).and_return(@movie_data)
 
-  #   end
+      viewing_party_request = {
+        name: "Test Party",
+        start_time: "2025-02-01 10:00:00",
+        end_time: "2025-02-01 10:30:00", 
+        movie_id: 278,
+        movie_title: "The Shawshank Redemption",
+        api_key: @host.api_key,
+        invitees: [{ id: @invitee1.id, name: @invitee1.name, username: @invitee1.username },
+                  { id: @invitee2.id, name: @invitee2.name, username: @invitee2.username }]
+      }
 
-  #   it "#create will only render correct user ids if some user ids are invalid" do
+      post "/api/v1/viewing_parties", params: viewing_party_request
 
-  #   end
-  # end
+      expect(response).to have_http_status(:unprocessable_entity)
+      error_response = JSON.parse(response.body, symbolize_names: true)
+      expect(error_response[:error]).to eq("Party duration can't be less than the movie runtime")
+    end
+
+    it "#create will render error if end time is before start time" do
+      @host = User.create!(:name => "Stef", :username => "steffy", :password => "231", api_key: Rails.application.credentials.dig(:tmdb, :key))
+
+      viewing_party_request = {
+        name: "Test Party",
+        start_time: "2025-02-01 10:00:00",
+        end_time: "2025-02-01 09:30:00", 
+        movie_id: 278,
+        movie_title: "The Shawshank Redemption",
+        api_key: @host.api_key,
+        invitees: [{ id: @invitee1.id, name: @invitee1.name, username: @invitee1.username },
+                  { id: @invitee2.id, name: @invitee2.name, username: @invitee2.username }]
+      }
+
+      post "/api/v1/viewing_parties", params: viewing_party_request
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      error_response = JSON.parse(response.body, symbolize_names: true)
+      expect(error_response[:error]).to eq("Party can't end before it starts")
+    end
+
+    it "#create will create a vp even if some user ids are invalid (minus those invalid ids)" do
+      @host = User.create!(:name => "Stef", :username => "steffy", :password => "231", api_key: Rails.application.credentials.dig(:tmdb, :key))
+      @wrong_id = 420
+      @movie_data
+
+      allow(MovieGateway).to receive(:show_movie_details).with(278).and_return(@movie_data)
+
+      viewing_party_request = {
+        name: "Test Party",
+        start_time: "2025-02-01 10:00:00",
+        end_time: "2025-02-01 12:30:00", 
+        movie_id: 278,
+        movie_title: "The Shawshank Redemption",
+        api_key: @host.api_key,
+        invitees: [{ id: @invitee1.id, name: @invitee1.name, username: @invitee1.username },
+                  { id: @invitee2.id, name: @invitee2.name, username: @invitee2.username },
+                  { id: @wrong_id, name: "Interloper", username: "nerdyguy" }]
+      }
+
+      post "/api/v1/viewing_parties", params: viewing_party_request
+
+      expect(response).to have_http_status(:created)
+      expect(response).to be_successful
+
+      json = JSON.parse(response.body, symbolize_names: true)
+      party = json[:data]
+      expect(party[:attributes][:invitees]).to eq([
+        {id: @invitee1.id, name: @invitee1.name, username: @invitee1.username},
+        {id: @invitee2.id, name: @invitee2.name, username: @invitee2.username}
+      ])
+    end
+  end
 end


### PR DESCRIPTION
### Create a Viewing Party
create a Viewing Party record and create the necessary joins records to invite all the indicated users
Note: The DB should be able to keep track of which user is the host of the party
require a valid API key be sent with the request
ignore any parameters in the request that are not allowed

new route
new models and many-to-many associations
new testing for viewing_parties_request_spec
viewing_party_serializer
viewing_parties_controller... big and handles a lot of logic, potential refactor into model.